### PR TITLE
Integrate codecov and add complete python3.7 support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,7 +15,7 @@
   "support_py2": "n",
   "use_pypi_deployment_with_travis": "y",
   "use_ghpages_deployment_with_travis": "y",
-  "integrate_codecov": "y",
+  "use_codecov": "y",
   "command_line_interface": ["Click", "No command-line interface"],
   "create_author_file": "y",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"]

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,6 +15,7 @@
   "support_py2": "n",
   "use_pypi_deployment_with_travis": "y",
   "use_ghpages_deployment_with_travis": "y",
+  "integrate_codecov": "y",
   "command_line_interface": ["Click", "No command-line interface"],
   "create_author_file": "y",
   "open_source_license": ["MIT license", "BSD license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Not open source"]

--- a/{{cookiecutter.repository_name}}/.travis.yml
+++ b/{{cookiecutter.repository_name}}/.travis.yml
@@ -16,7 +16,7 @@ matrix:
       sudo: required
 
 # Command to install dependencies
-{%- if cookiecutter.integrate_codecov == 'y' %}
+{%- if cookiecutter.use_codecov == 'y' %}
 install: pip install -U tox-travis codecov
 
 after_success: codecov

--- a/{{cookiecutter.repository_name}}/.travis.yml
+++ b/{{cookiecutter.repository_name}}/.travis.yml
@@ -1,4 +1,5 @@
 # Config file for automatic testing at travis-ci.org
+dist: trusty
 language: python
 python:
   - 3.6
@@ -8,8 +9,20 @@ python:
   - 2.7
 {%- endif %}
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: required
+
 # Command to install dependencies
+{%- if cookiecutter.integrate_codecov == 'y' %}
+install: pip install -U tox-travis codecov
+
+after_success: codecov
+{%- else %}
 install: pip install -U tox-travis
+{%- endif %}
 
 # Command to run tests
 script: tox
@@ -50,4 +63,3 @@ deploy:
       branch: master
       python: 3.6
 {%- endif %}
-

--- a/{{cookiecutter.repository_name}}/Makefile
+++ b/{{cookiecutter.repository_name}}/Makefile
@@ -39,7 +39,7 @@ install-test: clean-build clean-pyc ## install the package and test dependencies
 
 .PHONY: test
 test: ## run tests quickly with the default Python
-	python -m pytest
+	python -m pytest --basetemp=${ENVTMPDIR} --cov={{ cookiecutter.project_slug }}
 
 .PHONY: lint
 lint: ## check style with flake8 and isort
@@ -52,7 +52,7 @@ install-develop: clean-build clean-pyc ## install the package in editable mode a
 
 .PHONY: test-all
 test-all: ## run tests on every Python version with tox
-	tox
+	tox -r
 
 .PHONY: fix-lint
 fix-lint: ## fix lint issues using autoflake, autopep8, and isort
@@ -120,8 +120,8 @@ bumpversion-minor: ## Bump the version the next minor skipping the release
 bumpversion-major: ## Bump the version the next major skipping the release
 	bumpversion --no-tag major
 
-CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-CHANGELOG_LINES := $(shell git diff HEAD..stable HISTORY.md | wc -l)
+CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+CHANGELOG_LINES := $(shell git diff HEAD..origin/stable HISTORY.md 2>&1 | wc -l)
 
 .PHONY: check-release
 check-release: ## Check if the release can be made

--- a/{{cookiecutter.repository_name}}/setup.py
+++ b/{{cookiecutter.repository_name}}/setup.py
@@ -11,22 +11,21 @@ with open('README.md') as readme_file:
 with open('HISTORY.md') as history_file:
     history = history_file.read()
 
-requirements = [
+install_requires = [
     {%- if cookiecutter.command_line_interface|lower == 'click' %}'Click>=6.0',{%- endif %}
     {%- if cookiecutter.support_py2 == 'y' %}'six',{%- endif %}
 ]
 
-setup_requirements = [
+setup_requires = [
     'pytest-runner>=2.11.1',
 ]
 
-test_requirements = [
-    'coverage>=4.5.1',
+tests_require = [
     'pytest>=3.4.2',
-    'tox>=2.9.1',
+    'pytest-cov>=2.6.0',
 ]
 
-development_requirements = [
+development_requires = [
     # general
     'bumpversion>=0.5.3',
     'pip>=9.0.1',
@@ -38,16 +37,20 @@ development_requirements = [
     'sphinx_rtd_theme>=0.2.4',
 
     # style check
-    'flake8>=3.5.0',
+    'flake8>=3.7.7',
     'isort>=4.3.4',
 
     # fix style issues
-    'autoflake>=1.1',
-    'autopep8>=1.3.5',
+    'autoflake>=1.2',
+    'autopep8>=1.4.3',
 
     # distribute on PyPI
     'twine>=1.10.0',
     'wheel>=0.30.0',
+
+    # Advanced testing
+    'coverage>=4.5.1',
+    'tox>=2.9.1',
 ]
 
 {%- set license_classifiers = {
@@ -87,11 +90,11 @@ setup(
     },
     {%- endif %}
     extras_require={
-        'test': test_requirements,
-        'dev': development_requirements + test_requirements,
+        'test': tests_require,
+        'dev': development_requires + tests_require,
     },
     install_package_data=True,
-    install_requires=requirements,
+    install_requires=install_requires,
 {%- if cookiecutter.open_source_license in license_classifiers %}
     license='{{ cookiecutter.open_source_license }}',
 {%- endif %}
@@ -106,9 +109,9 @@ setup(
 {%- else %}
     python_requires='>=3.4',
 {%- endif %}
-    setup_requires=setup_requirements,
+    setup_requires=setup_requires,
     test_suite='tests',
-    tests_require=test_requirements,
+    tests_require=tests_require,
     url='https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.repository_name }}',
     version='{{ cookiecutter.version }}',
     zip_safe=False,

--- a/{{cookiecutter.repository_name}}/tox.ini
+++ b/{{cookiecutter.repository_name}}/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = {% if cookiecutter.support_py2 == 'y' %}py27, {% endif %}py34, py35, py36, flake8, docs
+envlist = {% if cookiecutter.support_py2 == 'y' %}py27, {% endif %}py34, py35, py36, py37, lint, docs
 
 
 [travis]
 python =
-    3.6: py36, docs, flake8
+    3.7: py37
+    3.6: py36, docs, lint
     3.5: py35
     3.4: py34
 {%- if cookiecutter.support_py2 == 'y' %}
@@ -13,24 +14,23 @@ python =
 
 
 [testenv]
+passenv = CI TRAVIS TRAVIS_*
 setenv =
     PYTHONPATH = {toxinidir}
 extras = test
 commands =
-    python -m pytest --basetemp={envtmpdir}
+    /usr/bin/env make test
 
 
-[testenv:flake8]
-deps =
-    flake8
-    isort
+[testenv:lint]
+skipsdist = true
+extras = dev
 commands =
     /usr/bin/env make lint
 
 
 [testenv:docs]
-setenv =
-    PYTHONPATH = {toxinidir}
+skipsdist = true
 extras = dev
 commands =
     /usr/bin/env make docs


### PR DESCRIPTION
Resolve #1: Integrate Codecov. Modified test requirements to add pytest-cov, and .travis.yml and tox.ini to add the necessary config.
Resolve #22 : changed the tox.ini structure to use make commands and extras.
Resolve #23 : added tox and coverage as development dependencies instead of test dependencies.
Resolve #24 : added the necessary configuration to support python3.7 on travis. For this, I had to add both the 3.7 config and the `dist: trusty`, otherwise the base image becomes `xenial` and the gh-pages deployment fails unless the branch exists beforehand.
Resolve #32 : Add `-r` flag to `make test-all` command to have `tox` regenerate the environment everytime it is is run.