### PR TITLE
Issues 25 36 38 setupcfg changes

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
   "license_owner": "{{ 'MIT Data To AI Lab' if cookiecutter.github_username != cookiecutter.github_owner else cookiecutter.full_name.replace(\"\\'\", \"\\\\\\'\") }}",
   "license_owner_email": "{{ 'dailabmit@gmail.com' if cookiecutter.github_username != cookiecutter.github_owner else cookiecutter.email }}",
   "pypi_username": "{{ 'mit_dai_lab' if cookiecutter.github_username != cookiecutter.github_owner else cookiecutter.github_username }}",
-  "version": "0.1.0",
+  "version": "0.1.0.dev0",
   "support_py2": "n",
   "use_pypi_deployment_with_travis": "y",
   "use_ghpages_deployment_with_travis": "y",

--- a/{{cookiecutter.repository_name}}/.editorconfig
+++ b/{{cookiecutter.repository_name}}/.editorconfig
@@ -11,7 +11,7 @@ charset = utf-8
 end_of_line = lf
 
 [*.py]
-max_line_length = 79
+max_line_length = 99
 
 [*.bat]
 indent_style = tab

--- a/{{cookiecutter.repository_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repository_name}}/CONTRIBUTING.rst
@@ -201,6 +201,24 @@ Once this is done, run of the following commands:
 
     make release-major
 
+Release Candidates
+~~~~~~~~~~~~~~~~~~
+
+Sometimes it is necessary or convenient to upload a release candidate to PyPi as a pre-release,
+in order to make some of the new features available for testing on other projects before they
+are included in an actual full-blown release.
+
+In order to perform such an action, you can execute::
+
+    make release-candidate
+
+This will perform the following actions:
+
+1. Build and upload the current version to PyPi as a pre-release, with the format ``X.Y.Z.devN``
+
+2. Bump the current version to the next release candidate, ``X.Y.Z.dev(N+1)``
+
+
 .. _GitHub issues page: https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.repository_name }}/issues
 .. _Travis Build Status page: https://travis-ci.org/{{ cookiecutter.github_owner }}/{{ cookiecutter.repository_name }}/pull_requests
 .. _Google docstrings style: https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments

--- a/{{cookiecutter.repository_name}}/CONTRIBUTING.rst
+++ b/{{cookiecutter.repository_name}}/CONTRIBUTING.rst
@@ -218,6 +218,19 @@ This will perform the following actions:
 
 2. Bump the current version to the next release candidate, ``X.Y.Z.dev(N+1)``
 
+After this is done, the new pre-release can be installed by including the ``dev`` section in the
+dependency specification, either in ``setup.py``::
+
+    install_requires = [
+        ...
+        '{{ cookiecutter.package_name }}>=X.Y.Z.dev',
+        ...
+    ]
+
+or in command line::
+
+    pip install '{{ cookiecutter.package_name }}>=X.Y.Z.dev'
+
 
 .. _GitHub issues page: https://github.com/{{ cookiecutter.github_owner }}/{{ cookiecutter.repository_name }}/issues
 .. _Travis Build Status page: https://travis-ci.org/{{ cookiecutter.github_owner }}/{{ cookiecutter.repository_name }}/pull_requests

--- a/{{cookiecutter.repository_name}}/HISTORY.md
+++ b/{{cookiecutter.repository_name}}/HISTORY.md
@@ -1,5 +1,1 @@
 # History
-
-## {{ cookiecutter.version.replace('-dev', '') }}
-
-* First release on PyPI.

--- a/{{cookiecutter.repository_name}}/Makefile
+++ b/{{cookiecutter.repository_name}}/Makefile
@@ -139,6 +139,9 @@ ifeq ($(CHANGELOG_LINES),0)
 	$(error Please insert the release notes in HISTORY.md before releasing)
 endif
 
+.PHONY: check-release
+check-release: check-master check-history ## Check if the release can be made
+
 .PHONY: release
 release: check-release bumpversion-release publish bumpversion-patch
 

--- a/{{cookiecutter.repository_name}}/Makefile
+++ b/{{cookiecutter.repository_name}}/Makefile
@@ -120,20 +120,30 @@ bumpversion-minor: ## Bump the version the next minor skipping the release
 bumpversion-major: ## Bump the version the next major skipping the release
 	bumpversion --no-tag major
 
+.PHONY: bumpversion-candidate
+bumpversion-candidate: ## Bump the version to the next candidate
+	bumpversion candidate --no-tag
+
 CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 CHANGELOG_LINES := $(shell git diff HEAD..origin/stable HISTORY.md 2>&1 | wc -l)
 
-.PHONY: check-release
-check-release: ## Check if the release can be made
+.PHONY: check-master
+check-master: ## Check if we are in master branch
 ifneq ($(CURRENT_BRANCH),master)
 	$(error Please make the release from master branch\n)
 endif
+
+.PHONY: check-history
+check-history: ## Check if HISTORY.md has been modified
 ifeq ($(CHANGELOG_LINES),0)
 	$(error Please insert the release notes in HISTORY.md before releasing)
 endif
 
 .PHONY: release
 release: check-release bumpversion-release publish bumpversion-patch
+
+.PHONY: release-candidate
+release-candidate: check-master publish bumpversion-candidate
 
 .PHONY: release-minor
 release-minor: check-release bumpversion-minor release

--- a/{{cookiecutter.repository_name}}/setup.cfg
+++ b/{{cookiecutter.repository_name}}/setup.cfg
@@ -26,13 +26,13 @@ replace = __version__ = '{new_version}'
 universal = 1
 
 [flake8]
-max-line-length = 79
+max-line-length = 99
 exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
 ignore = # keep empty to prevent default ignores
 
 [isort]
 include_trailing_comment = True
-line_length=79
+line_length=99
 lines_between_types = 0
 multi_line_output = 4
 not_skip = __init__.py

--- a/{{cookiecutter.repository_name}}/setup.cfg
+++ b/{{cookiecutter.repository_name}}/setup.cfg
@@ -2,17 +2,19 @@
 current_version = {{ cookiecutter.version }}
 commit = True
 tag = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<candidate>\d+))?
 serialize =
-    {major}.{minor}.{patch}-{release}
-    {major}.{minor}.{patch}
+	{major}.{minor}.{patch}-{release}{candidate}
+	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = release
+first_value = dev
 values =
-    dev
-    release
+	dev
+	release
 
+[bumpversion:part:candidate]
 
 [bumpversion:file:setup.py]
 search = version='{current_version}'


### PR DESCRIPTION
Resolve #25: Start on a development version instead of a released one.
Resolve #36: Add option to easily push release candidates to PyPi. New make command `make release-candidate` has been added, which pushes the current version to pypi as a new pre-release and makes the development version suffix advance on one step.
Resolve #38: Change the default max line length to 99.