### PR TITLE
Fix release candidate version specification format

### DIFF
--- a/{{cookiecutter.repository_name}}/setup.cfg
+++ b/{{cookiecutter.repository_name}}/setup.cfg
@@ -2,9 +2,9 @@
 current_version = {{ cookiecutter.version }}
 commit = True
 tag = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<candidate>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<release>[a-z]+)(?P<candidate>\d+))?
 serialize =
-	{major}.{minor}.{patch}-{release}{candidate}
+	{major}.{minor}.{patch}.{release}{candidate}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]


### PR DESCRIPTION
Fix release candidate version specification format in setup.cfg.
A couple of `-` should have been `.`.