### PR TITLE
Fix incorrect isort option

### DIFF
--- a/{{cookiecutter.repository_name}}/setup.cfg
+++ b/{{cookiecutter.repository_name}}/setup.cfg
@@ -36,7 +36,7 @@ exclude = docs, .tox, .git, __pycache__, .ipynb_checkpoints
 ignore = W503  
 
 [isort]
-include_trailing_comment = True
+include_trailing_comma = True
 line_length=99
 lines_between_types = 0
 multi_line_output = 4


### PR DESCRIPTION
The correct name is include_trailing_comma, see https://pycqa.github.io/isort/docs/configuration/options/#include-trailing-comma. A search through isort project history shows this other option never existed.